### PR TITLE
Add pylint check for python files

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,24 @@
+name: pylint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  pylint_check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.6'
+
+    - name: Install dependencies
+      run: python -m pip install --upgrade pip setuptools pylint pylint-exit
+
+    - name: Run Pylint Checks
+      run: pylint --rcfile=.pylintrc *.py distrobaker/*.py || pylint-exit --error-fail $?

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,17 @@
+[BASIC]
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,50}$
+
+[MESSAGES CONTROL]
+disable=
+  C0103,  # invalid-name
+  C0114,  # missing-module-docstring
+  E0401,  # import-error
+  W1202,  # logging-format-interpolation lazy % formatting in logging functions
+
+[REPORTS]
+msg-template='[{msg_id} {symbol}] {msg} File: {path}, line {line}, in {obj}'
+
+[FORMAT]
+# Maximum number of characters on a single line.
+max-line-length=120


### PR DESCRIPTION
[Pylint checker](https://www.pylint.org/) for python files like extended PEP8.
Successfully used in the [eln-build-pipeline](https://github.com/fedora-ci/eln-build-pipeline).

Github Actions [provides](https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources) only Ubuntu, macOS, and Windows OS, so checks will be run on Debian.
It is possible to run it in a Fedora container. But still, as a base OS will be Ubuntu.