### PR TITLE
Fix threading issue

### DIFF
--- a/distrobaker
+++ b/distrobaker
@@ -117,7 +117,7 @@ def main():
         logger.info('All components processed, exiting.')
     else:
         logger.info('Starting DistroBaker in the service mode.')
-        threading.Thread(target=update, args=(args.config, args.update * 60, configref, logger)).start()
+        threading.Thread(target=update, args=(args.config, args.update * 60, configref, logger), daemon=True).start()
         thread = threading.Thread(target=listen, args=(logger, ))
         thread.start()
         thread.join()


### PR DESCRIPTION
The issue:
```
threading.Thread(target=update, args=(args.config, args.update * 60, configref, logger)).start()
        thread = threading.Thread(target=listen, args=(logger, ))
        thread.start()
        thread.join()
```
There are two threads "update" and "listen"
if "listen" stops, python will not exit and will just forever run the "update" process.