### PR TITLE
Fix expiring koji sessions

### DIFF
--- a/lib/distrobaker.py
+++ b/lib/distrobaker.py
@@ -791,7 +791,7 @@ def get_buildsys(which):
     if 'main' not in c:
         logger.critical('DistroBaker is not configured, aborting.')
         return None
-    if which != 'source' and which != 'destination':
+    if which not in ('source', 'destination'):
         logger.error('Cannot get "%s" build system.', which)
         return None
     if not hasattr(get_buildsys, which):

--- a/lib/distrobaker.py
+++ b/lib/distrobaker.py
@@ -778,8 +778,8 @@ def get_build(comp, ns='rpms'):
         return None
     if ns == 'modules':
         logger.error('Modules not implemented, cannot get the latest build for %s/%s.', ns, comp)
-        return None
-    logger.error('Unrecognized namespace: %s/%s', ns, comp)
+    else:
+        logger.error('Unrecognized namespace: %s/%s', ns, comp)
     return None
 
 def get_buildsys(which):

--- a/lib/distrobaker.py
+++ b/lib/distrobaker.py
@@ -677,6 +677,7 @@ def process_message(msg):
             logger.debug('Message tag not configured as a trigger, ignoring.')
     else:
         logger.warning('Unable to handle %s topics, ignoring.', msg.topic)
+    return None
 
 def process_components(compset):
     """Processes the supplied set of components.  If the set is empty,
@@ -720,6 +721,7 @@ def process_components(compset):
         logger.info('Done processing %s.', rec)
         processed += 1
     logger.info('Synchronized %d component(s), %d skipped.', processed, len(compset) - processed)
+    return None
 
 def get_scmurl(nvr):
     """Get SCMURL for a source build system build NVR.  NVRs are unique.

--- a/lib/distrobaker.py
+++ b/lib/distrobaker.py
@@ -774,7 +774,7 @@ def get_build(comp, ns='rpms'):
             return nvr[0]['nvr']
         logger.error('Did not find any builds for %s/%s.', ns, comp)
         return None
-    elif ns == 'modules':
+    if ns == 'modules':
         logger.error('Modules not implemented, cannot get the latest build for %s/%s.', ns, comp)
         return None
     logger.error('Unrecognized namespace: %s/%s', ns, comp)


### PR DESCRIPTION
Submitting a build after a longer time of inactivity can cause an AuthError becuause the session on the destination build system has timed out. This commit adds a check for session age and forces a new login if the session is older than an hour.  
  
Also, fix some minor pylint issues.