### PR TITLE
Split of sync_repo() into smaller functions

### DIFF
--- a/distrobaker
+++ b/distrobaker
@@ -121,6 +121,8 @@ def main():
         logger.critical('Could not load configuration.')
         sys.exit(128)
     logger.info('Configuration loaded.')
+    if args.dry_run:
+        logger.info('Dry mode is enabled.  Nothing will be uploaded/pushed/built.')
     if args.oneshot:
         logger.info('Starting DistroBaker in the oneshot mode.')
         logger.warning('Modules currently not implemented and will be ignored.')


### PR DESCRIPTION
I'm not sure how to fully test this yet. However, running `./distrobaker -n -l debug -1 -s rpms/gzip ...` pointed to the `distrobaker_centos_stream_config` config repo completes without errors. I'm having authentication issues running the same command pointed at the `distrobaker_config` config repo--but I get the exact same issues running the unmodified code.